### PR TITLE
feat: add more types to polyfill wasmtime in js

### DIFF
--- a/crates/wasm-bridge-js/src/caller.rs
+++ b/crates/wasm-bridge-js/src/caller.rs
@@ -1,28 +1,28 @@
 use std::ops::{Deref, DerefMut};
 
-use crate::DataHandle;
+use crate::Store;
 
 #[derive(Debug)]
 pub struct Caller<T> {
-    handle: DataHandle<T>,
+    pub(crate) store: Store<T>,
 }
 
 impl<T> Caller<T> {
-    pub(crate) fn new(handle: DataHandle<T>) -> Self {
-        Self { handle }
+    pub(crate) fn new(store: Store<T>) -> Self {
+        Self { store }
     }
 
     pub fn data(&self) -> impl Deref<Target = T> + '_ {
-        self.handle.borrow()
+        self.store.data()
     }
 
     pub fn data_mut(&mut self) -> impl DerefMut<Target = T> + '_ {
-        self.handle.borrow_mut()
+        self.store.data_mut()
     }
 }
 
 impl<T> Clone for Caller<T> {
     fn clone(&self) -> Self {
-        Caller::new(self.handle.clone())
+        Caller::new(self.store.clone())
     }
 }

--- a/crates/wasm-bridge-js/src/context.rs
+++ b/crates/wasm-bridge-js/src/context.rs
@@ -1,4 +1,4 @@
-use crate::Store;
+use crate::{Caller, Store};
 
 pub trait AsContext {
     type Data;
@@ -30,6 +30,14 @@ impl<'a, T: AsContext> AsContext for &'a mut T {
     }
 }
 
+impl<T> AsContext for Caller<T> {
+    type Data = T;
+
+    fn as_context(&self) -> &Store<Self::Data> {
+        &self.store
+    }
+}
+
 pub trait AsContextMut: AsContext {
     fn as_context_mut(&mut self) -> &mut Store<Self::Data>;
 }
@@ -43,5 +51,11 @@ impl<T> AsContextMut for Store<T> {
 impl<'a, T: AsContextMut> AsContextMut for &'a mut T {
     fn as_context_mut(&mut self) -> &mut Store<Self::Data> {
         T::as_context_mut(*self)
+    }
+}
+
+impl<T> AsContextMut for Caller<T> {
+    fn as_context_mut(&mut self) -> &mut Store<Self::Data> {
+        &mut self.store
     }
 }

--- a/crates/wasm-bridge-js/src/conversions/from_js_value.rs
+++ b/crates/wasm-bridge-js/src/conversions/from_js_value.rs
@@ -310,3 +310,19 @@ from_js_value_many!((0, T0), (1, T1), (2, T2), (3, T3), (4, T4), (5, T5), (6, T6
 from_js_value_many!((0, T0), (1, T1), (2, T2), (3, T3), (4, T4), (5, T5), (6, T6), (7, T7), (8, T8), (9, T9), (10, T10));
 #[rustfmt::skip]
 from_js_value_many!((0, T0), (1, T1), (2, T2), (3, T3), (4, T4), (5, T5), (6, T6), (7, T7), (8, T8), (9, T9), (10, T10), (11, T11));
+
+impl FromJsValue for Val {
+    type WasmAbi = JsValue;
+
+    fn from_js_value(value: &JsValue) -> Result<Self> {
+        let number = match value.as_f64() {
+            Some(number) => Ok(number),
+            None => Err(map_js_error("Expected a number")(value)),
+        }?;
+        Ok(Val::F64(f64::to_bits(number)))
+    }
+
+    fn from_wasm_abi(abi: Self::WasmAbi) -> Result<Self> {
+        Self::from_js_value(&abi)
+    }
+}

--- a/crates/wasm-bridge-js/src/conversions/mod.rs
+++ b/crates/wasm-bridge-js/src/conversions/mod.rs
@@ -8,3 +8,76 @@ mod from_js_value_tests;
 pub use from_js_value::*;
 pub use into_closure::*;
 pub use to_js_value::*;
+
+/// Possible runtime values that a WebAssembly module can either consume or
+/// produce.
+#[derive(Debug, Clone)]
+pub enum Val {
+    // NB: the ordering here is intended to match the ordering in
+    // `ValType` to improve codegen when learning the type of a value.
+    /// A 32-bit integer
+    I32(i32),
+
+    /// A 64-bit integer
+    I64(i64),
+
+    /// A 32-bit float.
+    ///
+    /// Note that the raw bits of the float are stored here, and you can use
+    /// `f32::from_bits` to create an `f32` value.
+    F32(u32),
+
+    /// A 64-bit float.
+    ///
+    /// Note that the raw bits of the float are stored here, and you can use
+    /// `f64::from_bits` to create an `f64` value.
+    F64(u64),
+    // /// A 128-bit number
+    // V128(u128),
+    // /// A first-class reference to a WebAssembly function.
+    // ///
+    // /// `FuncRef(None)` is the null function reference, created by `ref.null
+    // /// func` in Wasm.
+    // FuncRef(Option<Func>),
+
+    // /// An `externref` value which can hold opaque data to the Wasm instance
+    // /// itself.
+    // ///
+    // /// `ExternRef(None)` is the null external reference, created by `ref.null
+    // /// extern` in Wasm.
+    // ExternRef(Option<ExternRef>),
+}
+
+impl Val {
+    pub fn i32(&self) -> Option<i32> {
+        match self {
+            Val::I32(i) => Some(*i),
+            Val::I64(i) => Some(*i as i32),
+            Val::F32(i) => Some(f32::from_bits(*i) as i32),
+            Val::F64(i) => Some(f64::from_bits(*i) as i32),
+            _ => None,
+        }
+    }
+
+    pub fn f32(&self) -> Option<f32> {
+        match self {
+            Val::I32(i) => Some(*i as f32),
+            Val::I64(i) => Some(*i as f32),
+            Val::F32(i) => Some(f32::from_bits(*i)),
+            Val::F64(i) => Some(f64::from_bits(*i as u64) as f32),
+            _ => None,
+        }
+    }
+}
+
+impl From<f32> for Val {
+    fn from(value: f32) -> Self {
+        Val::F32(f32::to_bits(value))
+    }
+}
+
+impl From<i32> for Val {
+    fn from(value: i32) -> Self {
+        Val::I32(value)
+    }
+}

--- a/crates/wasm-bridge-js/src/conversions/to_js_value.rs
+++ b/crates/wasm-bridge-js/src/conversions/to_js_value.rs
@@ -7,6 +7,8 @@ use wasm_bindgen::{
     JsValue,
 };
 
+use crate::Val;
+
 pub trait ToJsValue: Sized {
     type ReturnAbi: ReturnWasmAbi + IntoWasmAbi;
 
@@ -286,3 +288,39 @@ to_js_value_many!(10, (0, T0), (1, T1), (2, T2), (3, T3), (4, T4), (5, T5), (6, 
 to_js_value_many!(11, (0, T0), (1, T1), (2, T2), (3, T3), (4, T4), (5, T5), (6, T6), (7, T7), (8, T8), (9, T9), (10, T10));
 #[rustfmt::skip]
 to_js_value_many!(12, (0, T0), (1, T1), (2, T2), (3, T3), (4, T4), (5, T5), (6, T6), (7, T7), (8, T8), (9, T9), (10, T10), (11, T11));
+
+impl ToJsValue for Val {
+    type ReturnAbi = f64;
+
+    fn to_js_value(&self) -> JsValue {
+        let v = match self.clone() {
+            Val::I32(i) => i as f64,
+            Val::I64(i) => i as f64,
+            Val::F32(i) => f32::from_bits(i as u32) as f64,
+            Val::F64(i) => f64::from_bits(i),
+        };
+        JsValue::from_f64(v)
+    }
+
+    fn into_return_abi(self) -> Result<Self::ReturnAbi, JsValue> {
+        let v = match self.clone() {
+            Val::I32(i) => i as f64,
+            Val::I64(i) => i as f64,
+            Val::F32(i) => f32::from_bits(i as u32) as f64,
+            Val::F64(i) => f64::from_bits(i),
+        };
+        Ok(v)
+    }
+}
+
+impl ToJsValue for anyhow::Error {
+    type ReturnAbi = js_sys::Error;
+
+    fn to_js_value(&self) -> JsValue {
+        js_sys::Error::new(&format!("{:?}", self)).into()
+    }
+
+    fn into_return_abi(self) -> Result<Self::ReturnAbi, JsValue> {
+        Ok(js_sys::Error::new(&format!("{:?}", self)))
+    }
+}

--- a/crates/wasm-bridge-js/src/func.rs
+++ b/crates/wasm-bridge-js/src/func.rs
@@ -1,0 +1,50 @@
+use anyhow::bail;
+use js_sys::{Function, WebAssembly};
+
+use crate::{helpers::map_js_error, AsContextMut, Error, FromJsValue, ToJsValue, Val};
+
+pub struct Func {
+    instance: WebAssembly::Instance,
+    function: Function,
+}
+
+impl Func {
+    pub fn new(instance: WebAssembly::Instance, function: Function) -> Self {
+        Func { instance, function }
+    }
+
+    pub fn call(
+        &self,
+        _: impl AsContextMut,
+        params: &[Val],
+        results: &mut [Val],
+    ) -> Result<(), Error> {
+        let params = params
+            .iter()
+            .map(|val| val.to_js_value())
+            .collect::<js_sys::Array>();
+        let result = self
+            .function
+            .apply(&self.function, &params)
+            .map_err(map_js_error("Exported function threw an exception"))?;
+        let data = if result.is_array() {
+            Vec::<Val>::from_js_value(&result)?
+        } else if result.is_undefined() || result.is_null() {
+            vec![]
+        } else {
+            vec![Val::from_js_value(&result)?]
+        };
+        if data.len() != results.len() {
+            bail!(
+                "Exported function {} should have {} arguments, but it has {} instead.",
+                self.function.name().as_string().unwrap_or_default(),
+                results.len(),
+                data.len()
+            );
+        }
+        for (target, source) in results.iter_mut().zip(data.into_iter()) {
+            *target = source;
+        }
+        Ok(())
+    }
+}

--- a/crates/wasm-bridge-js/src/instance.rs
+++ b/crates/wasm-bridge-js/src/instance.rs
@@ -53,6 +53,23 @@ impl Instance {
             );
         }
 
-        Ok(TypedFunc::new(&self.instance, function))
+        Ok(TypedFunc::new(self.instance.clone(), function))
+    }
+
+    pub fn get_func(&self, _store: impl AsContextMut, name: &str) -> Option<Func> {
+        let function = Reflect::get(&self.exports, &name.into()).ok()?;
+
+        if !function.is_function() {
+            return None;
+        }
+
+        let function: Function = function.into();
+
+        Some(Func::new(self.instance.clone(), function))
+    }
+
+    pub fn get_memory<T>(&self, _: &mut Store<T>, id: &str) -> Option<Memory> {
+        let memory = Reflect::get(&self.exports, &id.into()).ok()?.into();
+        Some(Memory { memory })
     }
 }

--- a/crates/wasm-bridge-js/src/lib.rs
+++ b/crates/wasm-bridge-js/src/lib.rs
@@ -28,6 +28,12 @@ pub use config::*;
 mod context;
 pub use context::*;
 
+mod memory;
+pub use memory::*;
+
+mod func;
+pub use func::*;
+
 pub type Error = anyhow::Error;
 pub type Result<T, E = Error> = anyhow::Result<T, E>;
 

--- a/crates/wasm-bridge-js/src/linker.rs
+++ b/crates/wasm-bridge-js/src/linker.rs
@@ -4,12 +4,16 @@ use wasm_bindgen::JsValue;
 use crate::*;
 
 pub struct Linker<T> {
+    engine: Engine,
     fns: Vec<PreparedFn<T>>,
 }
 
 impl<T> Linker<T> {
-    pub fn new(_engine: &Engine) -> Self {
-        Self { fns: vec![] }
+    pub fn new(engine: &Engine) -> Self {
+        Self {
+            engine: engine.clone(),
+            fns: vec![],
+        }
     }
 
     pub fn instantiate(
@@ -39,7 +43,7 @@ impl<T> Linker<T> {
     where
         F: IntoMakeClosure<T, Params, Results> + 'static,
     {
-        let creator = func.into_make_closure();
+        let creator = func.into_make_closure(self.engine.clone());
 
         self.fns.push(PreparedFn::new(module, name, creator));
 

--- a/crates/wasm-bridge-js/src/memory.rs
+++ b/crates/wasm-bridge-js/src/memory.rs
@@ -1,0 +1,39 @@
+use js_sys::{Reflect, Uint8Array, WebAssembly};
+
+use crate::{helpers::map_js_error, AsContextMut, Error};
+
+#[derive(Clone)]
+pub struct Memory {
+    pub(crate) memory: WebAssembly::Memory,
+}
+
+impl Memory {
+    pub fn write(&self, _: impl AsContextMut, offset: usize, buffer: &[u8]) -> Result<(), Error> {
+        let memory = Reflect::get(&self.memory, &"buffer".into())
+            .map_err(map_js_error("Memory has no buffer field"))?;
+        let mem = Uint8Array::new_with_byte_offset_and_length(
+            &memory,
+            offset as u32,
+            buffer.len() as u32,
+        );
+        mem.copy_from(buffer);
+        Ok(())
+    }
+
+    pub fn read(
+        &self,
+        _: impl AsContextMut,
+        offset: usize,
+        buffer: &mut [u8],
+    ) -> Result<(), Error> {
+        let memory = Reflect::get(&self.memory, &"buffer".into())
+            .map_err(map_js_error("Memory has no buffer field"))?;
+        let mem = Uint8Array::new_with_byte_offset_and_length(
+            &memory,
+            offset as u32,
+            buffer.len() as u32,
+        );
+        mem.copy_to(buffer);
+        Ok(())
+    }
+}

--- a/crates/wasm-bridge-js/src/store.rs
+++ b/crates/wasm-bridge-js/src/store.rs
@@ -6,10 +6,10 @@ use std::{
 
 use crate::*;
 
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, Default)]
 pub struct Store<T> {
-    engine: Engine,
-    data: DataHandle<T>,
+    pub(crate) engine: Engine,
+    pub(crate) data: DataHandle<T>,
 }
 
 impl<T> Store<T> {
@@ -34,6 +34,19 @@ impl<T> Store<T> {
 
     pub(crate) fn data_handle(&self) -> &DataHandle<T> {
         &self.data
+    }
+
+    pub fn into_data(self) -> Option<T> {
+        Some(Rc::into_inner(self.data)?.into_inner())
+    }
+}
+
+impl<T> Clone for Store<T> {
+    fn clone(&self) -> Self {
+        Store {
+            engine: self.engine.clone(),
+            data: self.data.clone(),
+        }
     }
 }
 

--- a/crates/wasm-bridge-js/src/typed_func.rs
+++ b/crates/wasm-bridge-js/src/typed_func.rs
@@ -5,14 +5,14 @@ use crate::*;
 use std::marker::PhantomData;
 
 #[derive(Clone, Debug)]
-pub struct TypedFunc<'a, Params, Results> {
+pub struct TypedFunc<Params, Results> {
     _phantom: PhantomData<fn(params: Params) -> Results>,
-    instance: &'a WebAssembly::Instance,
+    instance: WebAssembly::Instance,
     function: Function,
 }
 
-impl<'a, Params: ToJsValue, Results: FromJsValue> TypedFunc<'a, Params, Results> {
-    pub(crate) fn new(instance: &'a WebAssembly::Instance, function: Function) -> Self {
+impl<Params: ToJsValue, Results: FromJsValue> TypedFunc<Params, Results> {
+    pub(crate) fn new(instance: WebAssembly::Instance, function: Function) -> Self {
         Self {
             _phantom: PhantomData,
             instance,


### PR DESCRIPTION
Hey I came across this project and I really like the idea. Here are some rough code I wrote to polyfill more wasmtime types and logic in `wasm-bridge`. Feel free to use or discard them or discuss the concept with me.

The main change to your design is that `Caller` now stores a `Store` so it could impl the `AsContext / AsContextMut` traits.

Have a nice day, friend.